### PR TITLE
feat(auth): asignar rol por defecto en registro de usuario #2 closes #2

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -40,6 +40,7 @@ class RegisteredUserController extends Controller
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
+            'role' => 'empleado',
         ]);
 
         event(new Registered($user));


### PR DESCRIPTION
Se agrega asignación de rol por defecto ('empleado') al registrar usuarios.

Se valida:
- name requerido
- email único
- password confirmado

Relacionado al Issue #2